### PR TITLE
simplify API so that we can get final solution with just one API network call

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,17 +37,9 @@ def complete_solver():
     if not all(inh in CASE_GEN.inheritors for inh in case):
         abort(400, "Inheritors must correspond to the config definition")
 
-    return full_solver(case)
+    radd_or_asaba_solved = full_solver(case)
 
-
-@app.route("/asl_shares", methods=["POST"])
-def asl_shares():
-    case = request.json
-
-    if not all(inh in CASE_GEN.inheritors for inh in case):
-        abort(400, "Inheritors must correspond to the config definition")
-
-    return calculate_asl(case)
+    return calculate_asl(radd_or_asaba_solved)
 
 
 @app.route("/generate_problems", methods=["POST"])


### PR DESCRIPTION
The thought process behind this is on the front end we may not need to show the Radd or Asaba shares calculation. Instead the user may just proceed to the final step which is finding the base of the problem and solving. IF so, it makes sense for the front end to have to just make one network call to the API in order to get the final answer which it can check against. 

Thoughts? 