### PR TITLE
handle empty must / not lists, fix error handling

### DIFF
--- a/inheritance_app.sh
+++ b/inheritance_app.sh
@@ -7,7 +7,7 @@ if [ -z "$1" ]; then
 fi
 
 # Default port
-PORT=2000
+PORT=3000
 
 # Check if a second argument (port) is provided for the build command
 if [ "$1" == "build" ] && [ -n "$2" ]; then

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from flask import Flask
 from flask import request
 from flask_cors import CORS, cross_origin
 
-import argparse
 from app.src.cases_generator import CaseGenerator
 from app.src.full_solver import full_solver
 from app.src.generate_unsolved_problems import generate_problems_lst
@@ -60,6 +59,14 @@ def solver():
 def generate_problems():
     problem_specs = request.json
 
+    assert isinstance(problem_specs, dict)
+
+    if "not_haves" not in problem_specs:
+        problem_specs["not_haves"] = []
+
+    if "must_haves" not in problem_specs:
+        problem_specs["must_haves"] = []
+
     if not problem_specs:
         abort(400, "The problem specs are empty")
 
@@ -69,10 +76,7 @@ def generate_problems():
             "The number of inheritors in a problem should be greater than or equal to 1",
         )
 
-    if not (
-        set(problem_specs["must_haves"]) - set(problem_specs["not_haves"])
-        or set(problem_specs["not_haves"]) - set(problem_specs["must_haves"])
-    ):
+    if set(problem_specs["must_haves"]).intersection(set(problem_specs["not_haves"])):
         abort(
             400,
             "An inheritor cannot be in both the must have and ignore list at the same time",

--- a/test_app.sh
+++ b/test_app.sh
@@ -1,4 +1,4 @@
 curl --header "Content-Type: application/json" \
   --request POST \
-  --data '{"must_haves": ["mother", "father"], "not_haves": [], "n_types": 3}' \
-  https://islamic-inheritance-api-2f1f200c92b2.herokuapp.com/generate_problems
+  --data '{"must_haves": ["mother", "father"], "not_haves": ["father"], "n_types": 3}' \
+  http://localhost:3000/generate_problems


### PR DESCRIPTION
- Handling requests with an empty `must_haves / not_haves` list since it's not required 
- Fixed error handling for detecting if an inheritor exists in both the must / not, previously was checking if the two sets are identical. 
